### PR TITLE
Optimization

### DIFF
--- a/Freesia-Common/src/main/java/com/nguyendevs/freesia/common/SslUtils.java
+++ b/Freesia-Common/src/main/java/com/nguyendevs/freesia/common/SslUtils.java
@@ -19,6 +19,8 @@ public class SslUtils {
             if (trustFile.exists()) {
                 EntryPoint.LOGGER_INST.info("\u001B[32m[Security] Client loading TrustStore from " + trustCertPath + "\u001B[0m");
                 builder.trustManager(trustFile);
+            } else {
+                EntryPoint.LOGGER_INST.warn("\u001B[31m[Security] Trust certificate not found at " + trustCertPath + ". SSL handshake will likely fail for self-signed certificates unless they are in the system trust store.\u001B[0m");
             }
         }
 

--- a/Freesia-Common/src/main/java/com/nguyendevs/freesia/common/communicating/NettySocketClient.java
+++ b/Freesia-Common/src/main/java/com/nguyendevs/freesia/common/communicating/NettySocketClient.java
@@ -11,6 +11,7 @@ import java.net.InetSocketAddress;
 import java.util.Queue;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.Function;
 
@@ -24,6 +25,7 @@ public class NettySocketClient {
     private final int reconnectInterval;
     private volatile Channel channel;
     private volatile boolean isConnected = false;
+    private final AtomicBoolean isConnecting = new AtomicBoolean(false);
 
     public NettySocketClient(InetSocketAddress masterAddress, Function<Channel, SimpleChannelInboundHandler<?>> handlerCreator, int reconnectInterval, io.netty.handler.ssl.SslContext sslContext) {
         this.masterAddress = masterAddress;
@@ -33,37 +35,52 @@ public class NettySocketClient {
     }
 
     public void connect() {
-        while (true) {
-            EntryPoint.LOGGER_INST.info("Connecting to master controller service.");
-            try {
-                new Bootstrap()
-                        .group(this.clientEventLoopGroup)
-                        .channel(this.clientChannelType)
-                        .option(ChannelOption.TCP_NODELAY, true)
-                        .handler(new ChannelInitializer<>() {
-                            @Override
-                            protected void initChannel(@NotNull Channel channel) {
-                                DefaultChannelPipelineLoader.loadDefaultHandlers(channel, NettySocketClient.this.sslContext, null);
-                                channel.pipeline().addLast(NettySocketClient.this.handlerCreator.apply(channel));
-                            }
-                        })
-                        .connect(this.masterAddress.getHostName(), this.masterAddress.getPort())
-                        .syncUninterruptibly();
-                this.isConnected = true;
-            } catch (Exception e) {
-                EntryPoint.LOGGER_INST.error("Failed to connect master controller service!", e);
-            }
+        if (!this.isConnecting.compareAndSet(false, true)) {
+            return;
+        }
 
-            if (this.isConnected) {
-                return;
-            }
+        final Thread connectionThread = new Thread(this::connectionLoop, "Freesia-Connection-Thread");
+        connectionThread.setDaemon(true);
+        connectionThread.start();
+    }
 
-            EntryPoint.LOGGER_INST.info("Trying to reconnect to the controller!");
-            LockSupport.parkNanos(TimeUnit.SECONDS.toNanos(this.reconnectInterval));
+    private void connectionLoop() {
+        try {
+            while (true) {
+                if (this.isConnected) {
+                    break;
+                }
 
-            if (!this.shouldDoNextReconnect()) {
-                return;
+                EntryPoint.LOGGER_INST.info("Connecting to master controller service.");
+                try {
+                    new Bootstrap()
+                            .group(this.clientEventLoopGroup)
+                            .channel(this.clientChannelType)
+                            .option(ChannelOption.TCP_NODELAY, true)
+                            .handler(new ChannelInitializer<>() {
+                                @Override
+                                protected void initChannel(@NotNull Channel channel) {
+                                    DefaultChannelPipelineLoader.loadDefaultHandlers(channel, NettySocketClient.this.sslContext, null);
+                                    channel.pipeline().addLast(NettySocketClient.this.handlerCreator.apply(channel));
+                                }
+                            })
+                            .connect(this.masterAddress.getHostName(), this.masterAddress.getPort())
+                            .sync();
+                    this.isConnected = true;
+                    break;
+                } catch (Exception e) {
+                    EntryPoint.LOGGER_INST.error("Failed to connect master controller service! (Reason: {})", e.getMessage());
+                }
+
+                EntryPoint.LOGGER_INST.info("Trying to reconnect to the controller in {}s!", this.reconnectInterval);
+                LockSupport.parkNanos(TimeUnit.SECONDS.toNanos(this.reconnectInterval));
+
+                if (!this.shouldDoNextReconnect()) {
+                    break;
+                }
             }
+        } finally {
+            this.isConnecting.set(false);
         }
     }
 

--- a/Freesia-Common/src/main/java/com/nguyendevs/freesia/common/communicating/NettySocketClient.java
+++ b/Freesia-Common/src/main/java/com/nguyendevs/freesia/common/communicating/NettySocketClient.java
@@ -33,35 +33,37 @@ public class NettySocketClient {
     }
 
     public void connect() {
-        EntryPoint.LOGGER_INST.info("Connecting to master controller service.");
-        try {
-            new Bootstrap()
-                    .group(this.clientEventLoopGroup)
-                    .channel(this.clientChannelType)
-                    .option(ChannelOption.TCP_NODELAY, true)
-                    .handler(new ChannelInitializer<>() {
-                        @Override
-                        protected void initChannel(@NotNull Channel channel) {
-                            DefaultChannelPipelineLoader.loadDefaultHandlers(channel, NettySocketClient.this.sslContext, null);
-                            channel.pipeline().addLast(NettySocketClient.this.handlerCreator.apply(channel));
-                        }
-                    })
-                    .connect(this.masterAddress.getHostName(), this.masterAddress.getPort())
-                    .syncUninterruptibly();
-            this.isConnected = true;
-        } catch (Exception e) {
-            EntryPoint.LOGGER_INST.error("Failed to connect master controller service!", e);
-        }
+        while (true) {
+            EntryPoint.LOGGER_INST.info("Connecting to master controller service.");
+            try {
+                new Bootstrap()
+                        .group(this.clientEventLoopGroup)
+                        .channel(this.clientChannelType)
+                        .option(ChannelOption.TCP_NODELAY, true)
+                        .handler(new ChannelInitializer<>() {
+                            @Override
+                            protected void initChannel(@NotNull Channel channel) {
+                                DefaultChannelPipelineLoader.loadDefaultHandlers(channel, NettySocketClient.this.sslContext, null);
+                                channel.pipeline().addLast(NettySocketClient.this.handlerCreator.apply(channel));
+                            }
+                        })
+                        .connect(this.masterAddress.getHostName(), this.masterAddress.getPort())
+                        .syncUninterruptibly();
+                this.isConnected = true;
+            } catch (Exception e) {
+                EntryPoint.LOGGER_INST.error("Failed to connect master controller service!", e);
+            }
 
-        if (!this.isConnected) {
+            if (this.isConnected) {
+                return;
+            }
+
             EntryPoint.LOGGER_INST.info("Trying to reconnect to the controller!");
             LockSupport.parkNanos(TimeUnit.SECONDS.toNanos(this.reconnectInterval));
 
             if (!this.shouldDoNextReconnect()) {
                 return;
             }
-
-            this.connect();
         }
     }
 

--- a/Freesia-Common/src/main/java/com/nguyendevs/freesia/common/communicating/handler/NettyClientChannelHandlerLayer.java
+++ b/Freesia-Common/src/main/java/com/nguyendevs/freesia/common/communicating/handler/NettyClientChannelHandlerLayer.java
@@ -24,6 +24,12 @@ public abstract class NettyClientChannelHandlerLayer extends SimpleChannelInboun
         if (cause instanceof java.io.IOException) {
             return;
         }
+
+        if (cause instanceof io.netty.handler.codec.DecoderException && cause.getCause() instanceof javax.net.ssl.SSLHandshakeException) {
+            EntryPoint.LOGGER_INST.error("SSL handshake failed: {}", cause.getCause().getMessage());
+            return;
+        }
+
         EntryPoint.LOGGER_INST.error("Exception caught in Client channel: ", cause);
     }
 

--- a/Freesia-Common/src/main/java/com/nguyendevs/freesia/common/communicating/handler/NettyServerChannelHandlerLayer.java
+++ b/Freesia-Common/src/main/java/com/nguyendevs/freesia/common/communicating/handler/NettyServerChannelHandlerLayer.java
@@ -37,6 +37,12 @@ public abstract class NettyServerChannelHandlerLayer extends SimpleChannelInboun
         if (cause instanceof java.io.IOException) {
             return;
         }
+
+        if (cause instanceof io.netty.handler.codec.DecoderException && cause.getCause() instanceof javax.net.ssl.SSLHandshakeException) {
+            EntryPoint.LOGGER_INST.error("SSL handshake failed: {}", cause.getCause().getMessage());
+            return;
+        }
+
         EntryPoint.LOGGER_INST.error("Exception caught in Server channel: ", cause);
     }
 

--- a/Freesia-Velocity/src/main/java/com/nguyendevs/freesia/velocity/YsmClientKickingDetector.java
+++ b/Freesia-Velocity/src/main/java/com/nguyendevs/freesia/velocity/YsmClientKickingDetector.java
@@ -17,7 +17,7 @@ public class YsmClientKickingDetector implements Runnable {
     private volatile ScheduledTask lastScheduled = null;
 
     public YsmClientKickingDetector() {
-        this.timeOut = FreesiaConfig.ysmDetectionTimeout * 1000L * 1000L;
+        this.timeOut = TimeUnit.MILLISECONDS.toNanos(FreesiaConfig.ysmDetectionTimeout);
     }
 
     public void onPlayerJoin(Player player) {

--- a/Freesia-Velocity/src/main/java/com/nguyendevs/freesia/velocity/network/backend/MasterServerMessageHandler.java
+++ b/Freesia-Velocity/src/main/java/com/nguyendevs/freesia/velocity/network/backend/MasterServerMessageHandler.java
@@ -18,10 +18,13 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.StampedLock;
 import java.util.function.Consumer;
 import java.util.Map;
+import java.util.Set;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 public class MasterServerMessageHandler extends NettyServerChannelHandlerLayer {
+    private static final Set<String> ALLOWED_COMMAND_PREFIXES = Set.of("freesia");
+
     private final Map<Integer, Consumer<String>> pendingCommandDispatches = Maps.newConcurrentMap();
     private final AtomicInteger traceIdGenerator = new AtomicInteger(0);
 
@@ -165,6 +168,13 @@ public class MasterServerMessageHandler extends NettyServerChannelHandlerLayer {
 
     @Override
     public void onCommandFromWorker(String command) {
-        Freesia.PROXY_SERVER.getCommandManager().executeAsync(Freesia.PROXY_SERVER.getConsoleCommandSource(), command);
+        final String trimmed = command.trim();
+        final String lower = trimmed.toLowerCase();
+        final boolean allowed = ALLOWED_COMMAND_PREFIXES.stream().anyMatch(p -> lower.startsWith(p + " ") || lower.equals(p));
+        if (!allowed) {
+            EntryPoint.LOGGER_INST.warn("[Security] Worker attempted to execute unauthorized command: {}", trimmed);
+            return;
+        }
+        Freesia.PROXY_SERVER.getCommandManager().executeAsync(Freesia.PROXY_SERVER.getConsoleCommandSource(), trimmed);
     }
 }

--- a/Freesia-Velocity/src/main/java/com/nguyendevs/freesia/velocity/network/misc/CitizensPersistenceManager.java
+++ b/Freesia-Velocity/src/main/java/com/nguyendevs/freesia/velocity/network/misc/CitizensPersistenceManager.java
@@ -4,6 +4,8 @@ import com.nguyendevs.freesia.velocity.Freesia;
 import com.nguyendevs.freesia.velocity.FreesiaConstants;
 
 import java.io.*;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -31,15 +33,23 @@ public class CitizensPersistenceManager {
     }
 
     public void saveModelBinaryCache(Map<String, byte[]> cache) {
-        try (DataOutputStream out = new DataOutputStream(new BufferedOutputStream(new FileOutputStream(MODEL_CACHE_FILE)))) {
-            out.writeInt(cache.size());
-            for (Map.Entry<String, byte[]> e : cache.entrySet()) {
-                out.writeUTF(e.getKey());
-                out.writeInt(e.getValue().length);
-                out.write(e.getValue());
+        final File tempFile = new File(MODEL_CACHE_FILE.getParentFile(), MODEL_CACHE_FILE.getName() + ".tmp");
+        try {
+            try (DataOutputStream out = new DataOutputStream(new BufferedOutputStream(new FileOutputStream(tempFile)))) {
+                out.writeInt(cache.size());
+                for (Map.Entry<String, byte[]> e : cache.entrySet()) {
+                    out.writeUTF(e.getKey());
+                    out.writeInt(e.getValue().length);
+                    out.write(e.getValue());
+                }
+                out.flush();
             }
+            Files.move(tempFile.toPath(), MODEL_CACHE_FILE.toPath(), StandardCopyOption.REPLACE_EXISTING, StandardCopyOption.ATOMIC_MOVE);
         } catch (Exception e) {
             Freesia.LOGGER.warn("[Citizens] Failed to save citizens_model_cache.dat: {}", e.getMessage());
+            if (tempFile.exists()) {
+                tempFile.delete();
+            }
         }
     }
 }

--- a/Freesia-Velocity/src/main/java/com/nguyendevs/freesia/velocity/network/ysm/RealPlayerYsmPacketProxyImpl.java
+++ b/Freesia-Velocity/src/main/java/com/nguyendevs/freesia/velocity/network/ysm/RealPlayerYsmPacketProxyImpl.java
@@ -81,7 +81,7 @@ public class RealPlayerYsmPacketProxyImpl extends YsmPacketProxyLayer {
                             this.releaseWriteReference();
 
                             this.notifyFullTrackerUpdates();
-                        }).join();
+                        });
             } catch (Exception e) {
                 Freesia.LOGGER.error("Failed to process entity state update packet", e);
             }

--- a/Freesia-Velocity/src/main/java/com/nguyendevs/freesia/velocity/network/ysm/YsmMapperPayloadManager.java
+++ b/Freesia-Velocity/src/main/java/com/nguyendevs/freesia/velocity/network/ysm/YsmMapperPayloadManager.java
@@ -28,6 +28,8 @@ import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
@@ -44,8 +46,7 @@ public class YsmMapperPayloadManager {
     private final Map<Player, MapperSessionProcessor> mapperSessions = Maps.newConcurrentMap();
     private final Function<Player, YsmPacketProxy> packetProxyCreator;
 
-    private final ReadWriteLock backendIpsAccessLock = new ReentrantReadWriteLock(false);
-    private final Map<InetSocketAddress, Integer> backend2Players = Maps.newLinkedHashMap();
+    private final Map<InetSocketAddress, LongAdder> backend2Players = Maps.newConcurrentMap();
     private final Set<UUID> ysmInstalledPlayers = Sets.newConcurrentHashSet();
 
     private final Map<InetSocketAddress, Map<Integer, Integer>> worker2PlayerEntityIdCache = Maps.newConcurrentMap();
@@ -63,7 +64,7 @@ public class YsmMapperPayloadManager {
             Function<UUID, YsmPacketProxy> packetProxyCreatorVirtual) {
         this.packetProxyCreator = packetProxyCreator;
         this.packetProxyCreatorVirtual = packetProxyCreatorVirtual;
-        this.backend2Players.put(FreesiaConfig.workerMSessionAddress, 1);
+        this.backend2Players.computeIfAbsent(FreesiaConfig.workerMSessionAddress, k -> new LongAdder());
         this.citizensModelBinaryCache.putAll(this.citizensPersistenceManager.loadModelBinaryCache());
     }
 
@@ -396,11 +397,17 @@ public class YsmMapperPayloadManager {
         final MapperSessionProcessor mapperSession = this.mapperSessions.remove(player);
 
         if (mapperSession != null) {
+            final InetSocketAddress remoteAddress = mapperSession.getRemoteAddress();
+            if (remoteAddress != null) {
+                final LongAdder adder = this.backend2Players.get(remoteAddress);
+                if (adder != null) {
+                    adder.decrement();
+                }
+            }
+
             this.disconnectMapperWithoutKickingMaster(mapperSession);
 
             final int workerEntityId = mapperSession.getPacketProxy().getPlayerWorkerEntityId();
-            final InetSocketAddress remoteAddress = mapperSession.getRemoteAddress();
-
             if (workerEntityId != -1 && remoteAddress != null) {
                 final Map<Integer, Integer> workerMap = this.worker2PlayerEntityIdCache.get(remoteAddress);
 
@@ -597,6 +604,11 @@ public class YsmMapperPayloadManager {
         mapperSession.setFlag(BuiltinFlags.READ_TIMEOUT, 30_000);
         mapperSession.setFlag(BuiltinFlags.WRITE_TIMEOUT, 30_000);
 
+        final LongAdder adder = this.backend2Players.get(backend);
+        if (adder != null) {
+            adder.increment();
+        }
+
         mapperSession.connect(true, false);
     }
 
@@ -636,32 +648,19 @@ public class YsmMapperPayloadManager {
 
     @Nullable
     private InetSocketAddress selectLessPlayer() {
-        this.backendIpsAccessLock.readLock().lock();
-        try {
-            InetSocketAddress result = null;
+        InetSocketAddress result = null;
+        long lastCount = Long.MAX_VALUE;
 
-            int idx = 0;
-            int lastCount = 0;
-            for (Map.Entry<InetSocketAddress, Integer> entry : this.backend2Players.entrySet()) {
-                final InetSocketAddress currAddress = entry.getKey();
-                final int currPlayerCount = entry.getValue();
+        for (Map.Entry<InetSocketAddress, LongAdder> entry : this.backend2Players.entrySet()) {
+            final InetSocketAddress currAddress = entry.getKey();
+            final long currPlayerCount = entry.getValue().sum();
 
-                if (idx == 0) {
-                    lastCount = currPlayerCount;
-                    result = currAddress;
-                }
-
-                if (currPlayerCount < lastCount) {
-                    lastCount = currPlayerCount;
-                    result = currAddress;
-                }
-
-                idx++;
+            if (result == null || currPlayerCount < lastCount) {
+                lastCount = currPlayerCount;
+                result = currAddress;
             }
-
-            return result;
-        } finally {
-            this.backendIpsAccessLock.readLock().unlock();
         }
+
+        return result;
     }
 }

--- a/Freesia-Velocity/src/main/java/com/nguyendevs/freesia/velocity/network/ysm/YsmPacketProxyLayer.java
+++ b/Freesia-Velocity/src/main/java/com/nguyendevs/freesia/velocity/network/ysm/YsmPacketProxyLayer.java
@@ -20,6 +20,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 public abstract class YsmPacketProxyLayer implements YsmPacketProxy {
     protected final Player player;
@@ -41,8 +42,8 @@ public abstract class YsmPacketProxyLayer implements YsmPacketProxy {
     private boolean proxyReady = false;
 
     private volatile Set<UUID> cachedTrackerList = Collections.emptySet();
-    private volatile long lastTrackerFetchMs = 0L;
-    private static final long TRACKER_CACHE_TTL_MS = 100L;
+    private volatile long lastTrackerFetchNs = 0L;
+    private static final long TRACKER_CACHE_TTL_NS = TimeUnit.MILLISECONDS.toNanos(100L);
 
     protected static final VarHandle ENTITY_DATA_REF_COUNT_HANDLE = ConcurrentUtil
             .getVarHandle(YsmPacketProxyLayer.class, "entityDataReferenceCount", int.class);
@@ -229,8 +230,8 @@ public abstract class YsmPacketProxyLayer implements YsmPacketProxy {
 
         this.sendEntityStateToRaw(this.playerUUID, currEntityId, currEntityData);
 
-        final long now = System.currentTimeMillis();
-        if (now - this.lastTrackerFetchMs > TRACKER_CACHE_TTL_MS) {
+        final long now = System.nanoTime();
+        if (now - this.lastTrackerFetchNs > TRACKER_CACHE_TTL_NS) {
             this.fetchTrackerList(this.playerUUID).whenComplete((result, ex) -> {
                 if (ex != null) {
                     Freesia.LOGGER.warn("Failed to fetch tracker list for player uuid {}: {}",
@@ -240,7 +241,7 @@ public abstract class YsmPacketProxyLayer implements YsmPacketProxy {
 
                 if (result != null) {
                     this.cachedTrackerList = result;
-                    this.lastTrackerFetchMs = System.currentTimeMillis();
+                    this.lastTrackerFetchNs = System.nanoTime();
                 }
 
                 this.broadcastStateToTrackers(currEntityId, currEntityData, result);

--- a/Freesia-Velocity/src/main/java/com/nguyendevs/freesia/velocity/network/ysm/YsmPacketProxyLayer.java
+++ b/Freesia-Velocity/src/main/java/com/nguyendevs/freesia/velocity/network/ysm/YsmPacketProxyLayer.java
@@ -15,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.invoke.VarHandle;
+import java.util.Collections;
 import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
@@ -38,6 +39,10 @@ public abstract class YsmPacketProxyLayer implements YsmPacketProxy {
     private YsmState lastYsmEntityData = null;
 
     private boolean proxyReady = false;
+
+    private volatile Set<UUID> cachedTrackerList = Collections.emptySet();
+    private volatile long lastTrackerFetchMs = 0L;
+    private static final long TRACKER_CACHE_TTL_MS = 100L;
 
     protected static final VarHandle ENTITY_DATA_REF_COUNT_HANDLE = ConcurrentUtil
             .getVarHandle(YsmPacketProxyLayer.class, "entityDataReferenceCount", int.class);
@@ -224,23 +229,37 @@ public abstract class YsmPacketProxyLayer implements YsmPacketProxy {
 
         this.sendEntityStateToRaw(this.playerUUID, currEntityId, currEntityData);
 
-        this.fetchTrackerList(this.playerUUID).whenComplete((result, ex) -> {
-            if (ex != null) {
-                Freesia.LOGGER.warn("Failed to fetch tracker list for player uuid {}: {}",
-                        this.player != null ? this.player.getUniqueId() : this.playerUUID, ex);
-                return;
-            }
+        final long now = System.currentTimeMillis();
+        if (now - this.lastTrackerFetchMs > TRACKER_CACHE_TTL_MS) {
+            this.fetchTrackerList(this.playerUUID).whenComplete((result, ex) -> {
+                if (ex != null) {
+                    Freesia.LOGGER.warn("Failed to fetch tracker list for player uuid {}: {}",
+                            this.player != null ? this.player.getUniqueId() : this.playerUUID, ex);
+                    return;
+                }
 
-            for (UUID toSend : result) {
-                final Optional<Player> queryResult = Freesia.PROXY_SERVER.getPlayer(toSend);
+                if (result != null) {
+                    this.cachedTrackerList = result;
+                    this.lastTrackerFetchMs = System.currentTimeMillis();
+                }
 
-                if (queryResult.isPresent()) {
-                    if (Freesia.mapperManager.isPlayerInstalledYsm(toSend)) {
-                        this.sendEntityStateToRaw(toSend, currEntityId, currEntityData);
-                    }
+                this.broadcastStateToTrackers(currEntityId, currEntityData, result);
+            });
+        } else {
+            this.broadcastStateToTrackers(currEntityId, currEntityData, this.cachedTrackerList);
+        }
+    }
+
+    private void broadcastStateToTrackers(int entityId, YsmState data, Set<UUID> trackers) {
+        if (trackers == null) return;
+        for (UUID toSend : trackers) {
+            final Optional<Player> queryResult = Freesia.PROXY_SERVER.getPlayer(toSend);
+            if (queryResult.isPresent()) {
+                if (Freesia.mapperManager.isPlayerInstalledYsm(toSend)) {
+                    this.sendEntityStateToRaw(toSend, entityId, data);
                 }
             }
-        });
+        }
     }
 
     public abstract CompletableFuture<Set<UUID>> fetchTrackerList(UUID observer);

--- a/Freesia-Velocity/src/main/java/com/nguyendevs/freesia/velocity/storage/DefaultRealPlayerDataStorageManagerImpl.java
+++ b/Freesia-Velocity/src/main/java/com/nguyendevs/freesia/velocity/storage/DefaultRealPlayerDataStorageManagerImpl.java
@@ -23,19 +23,7 @@ public class DefaultRealPlayerDataStorageManagerImpl implements IDataStorageMana
             }
 
             try {
-                final byte[] data =  Files.readAllBytes(targetFile.toPath());
-                final ByteArrayInputStream inputStream = new ByteArrayInputStream(data);
-                final DataInputStream dataInputStream = new DataInputStream(inputStream);
-
-                final DefaultNBTSerializer codec = new DefaultNBTSerializer();
-
-                final NBTCompound deserialized = (NBTCompound) codec.deserializeTag(NBTLimiter.noop(), dataInputStream, true);
-
-                final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-                final DataOutputStream dataOutputStream = new DataOutputStream(outputStream);
-                codec.serializeTag(dataOutputStream, deserialized, false);
-
-                return outputStream.toByteArray();
+                return Files.readAllBytes(targetFile.toPath());
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
@@ -49,18 +37,10 @@ public class DefaultRealPlayerDataStorageManagerImpl implements IDataStorageMana
             final File targetFile = new File(FreesiaConstants.FileConstants.PLAYER_DATA_DIR, playerUUID + ".nbt");
 
             try {
-                final ByteArrayInputStream inputStream = new ByteArrayInputStream(content);
-                final DataInputStream dataInputStream = new DataInputStream(inputStream);
-
                 final DefaultNBTSerializer codec = new DefaultNBTSerializer();
+                codec.deserializeTag(NBTLimiter.forBuffer(content, 2 * 1024 * 1024), new DataInputStream(new ByteArrayInputStream(content)), false);
 
-                final NBTCompound deserialized = (NBTCompound) codec.deserializeTag(NBTLimiter.noop(), dataInputStream, false);
-
-                final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-                final DataOutputStream dataOutputStream = new DataOutputStream(outputStream);
-                codec.serializeTag(dataOutputStream, deserialized, true);
-
-                Files.write(targetFile.toPath(), outputStream.toByteArray());
+                Files.write(targetFile.toPath(), content);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/Freesia-Velocity/src/main/java/com/nguyendevs/freesia/velocity/storage/DefaultVirtualPlayerDataStorageManagerImpl.java
+++ b/Freesia-Velocity/src/main/java/com/nguyendevs/freesia/velocity/storage/DefaultVirtualPlayerDataStorageManagerImpl.java
@@ -22,19 +22,7 @@ public class DefaultVirtualPlayerDataStorageManagerImpl implements IDataStorageM
             }
 
             try {
-                final byte[] data =  Files.readAllBytes(targetFile.toPath());
-                final ByteArrayInputStream inputStream = new ByteArrayInputStream(data);
-                final DataInputStream dataInputStream = new DataInputStream(inputStream);
-
-                final DefaultNBTSerializer codec = new DefaultNBTSerializer();
-
-                final NBTCompound deserialized = (NBTCompound) codec.deserializeTag(NBTLimiter.noop(), dataInputStream, true);
-
-                final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-                final DataOutputStream dataOutputStream = new DataOutputStream(outputStream);
-                codec.serializeTag(dataOutputStream, deserialized, false);
-
-                return outputStream.toByteArray();
+                return Files.readAllBytes(targetFile.toPath());
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
@@ -48,18 +36,10 @@ public class DefaultVirtualPlayerDataStorageManagerImpl implements IDataStorageM
             final File targetFile = new File(FreesiaConstants.FileConstants.VIRTUAL_PLAYER_DATA_DIR, playerUUID + ".dat");
 
             try {
-                final ByteArrayInputStream inputStream = new ByteArrayInputStream(content);
-                final DataInputStream dataInputStream = new DataInputStream(inputStream);
-
                 final DefaultNBTSerializer codec = new DefaultNBTSerializer();
+                codec.deserializeTag(NBTLimiter.forBuffer(content, 2 * 1024 * 1024), new DataInputStream(new ByteArrayInputStream(content)), false);
 
-                final NBTCompound deserialized = (NBTCompound) codec.deserializeTag(NBTLimiter.noop(), dataInputStream, false);
-
-                final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-                final DataOutputStream dataOutputStream = new DataOutputStream(outputStream);
-                codec.serializeTag(dataOutputStream, deserialized, true);
-
-                Files.write(targetFile.toPath(), outputStream.toByteArray());
+                Files.write(targetFile.toPath(), content);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/Freesia-Waterfall/src/main/java/com/nguyendevs/freesia/waterfall/YsmClientKickingDetector.java
+++ b/Freesia-Waterfall/src/main/java/com/nguyendevs/freesia/waterfall/YsmClientKickingDetector.java
@@ -17,7 +17,7 @@ public class YsmClientKickingDetector implements Runnable {
     private volatile ScheduledTask lastScheduled = null;
 
     public YsmClientKickingDetector() {
-        this.timeOut = FreesiaConfig.ysmDetectionTimeout * 1000L * 1000L;
+        this.timeOut = TimeUnit.MILLISECONDS.toNanos(FreesiaConfig.ysmDetectionTimeout);
     }
 
     public void onPlayerJoin(ProxiedPlayer player) {

--- a/Freesia-Waterfall/src/main/java/com/nguyendevs/freesia/waterfall/network/backend/MasterServerMessageHandler.java
+++ b/Freesia-Waterfall/src/main/java/com/nguyendevs/freesia/waterfall/network/backend/MasterServerMessageHandler.java
@@ -15,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -23,6 +24,8 @@ import java.util.concurrent.locks.StampedLock;
 import java.util.function.Consumer;
 
 public class MasterServerMessageHandler extends NettyServerChannelHandlerLayer {
+    private static final Set<String> ALLOWED_COMMAND_PREFIXES = Set.of("freesia");
+
     private final Map<Integer, Consumer<String>> pendingCommandDispatches = Maps.newConcurrentMap();
     private final AtomicInteger traceIdGenerator = new AtomicInteger(0);
 
@@ -167,6 +170,13 @@ public class MasterServerMessageHandler extends NettyServerChannelHandlerLayer {
 
     @Override
     public void onCommandFromWorker(String command) {
-        Freesia.PROXY_SERVER.getPluginManager().dispatchCommand(Freesia.PROXY_SERVER.getConsole(), command);
+        final String trimmed = command.trim();
+        final String lower = trimmed.toLowerCase();
+        final boolean allowed = ALLOWED_COMMAND_PREFIXES.stream().anyMatch(p -> lower.startsWith(p + " ") || lower.equals(p));
+        if (!allowed) {
+            EntryPoint.LOGGER_INST.warn("[Security] Worker attempted to execute unauthorized command: {}", trimmed);
+            return;
+        }
+        Freesia.PROXY_SERVER.getPluginManager().dispatchCommand(Freesia.PROXY_SERVER.getConsole(), trimmed);
     }
 }

--- a/Freesia-Waterfall/src/main/java/com/nguyendevs/freesia/waterfall/network/ysm/YsmMapperPayloadManager.java
+++ b/Freesia-Waterfall/src/main/java/com/nguyendevs/freesia/waterfall/network/ysm/YsmMapperPayloadManager.java
@@ -26,6 +26,8 @@ import java.io.DataOutputStream;
 import java.net.InetSocketAddress;
 import java.util.*;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.LongAdder;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
@@ -43,8 +45,7 @@ public class YsmMapperPayloadManager {
 
     private final Function<ProxiedPlayer, YsmPacketProxy> packetProxyCreator;
 
-    private final ReadWriteLock backendIpsAccessLock = new ReentrantReadWriteLock(false);
-    private final Map<InetSocketAddress, Integer> backend2Players = Maps.newLinkedHashMap();
+    private final Map<InetSocketAddress, LongAdder> backend2Players = Maps.newConcurrentMap();
 
     private final Set<UUID> ysmInstalledPlayers = Sets.newConcurrentHashSet();
 
@@ -62,7 +63,7 @@ public class YsmMapperPayloadManager {
             Function<UUID, YsmPacketProxy> packetProxyCreatorVirtual) {
         this.packetProxyCreator = packetProxyCreator;
         this.packetProxyCreatorVirtual = packetProxyCreatorVirtual;
-        this.backend2Players.put(FreesiaConfig.workerMSessionAddress, 1);
+        this.backend2Players.computeIfAbsent(FreesiaConfig.workerMSessionAddress, k -> new LongAdder());
         this.citizensModelBinaryCache.putAll(this.citizensPersistenceManager.loadModelBinaryCache());
     }
 
@@ -399,11 +400,17 @@ public class YsmMapperPayloadManager {
         final MapperSessionProcessor mapperSession = this.mapperSessions.get(player);
 
         if (mapperSession != null) {
+            final InetSocketAddress remoteAddress = mapperSession.getRemoteAddress();
+            if (remoteAddress != null) {
+                final LongAdder adder = this.backend2Players.get(remoteAddress);
+                if (adder != null) {
+                    adder.decrement();
+                }
+            }
+
             this.disconnectMapperWithoutKickingMaster(mapperSession);
 
             final int workerEntityId = mapperSession.getPacketProxy().getPlayerWorkerEntityId();
-            final InetSocketAddress remoteAddress = mapperSession.getRemoteAddress();
-
             if (workerEntityId != -1 && remoteAddress != null) {
                 final Map<Integer, Integer> workerMap = this.worker2PlayerEntityIdCache.get(remoteAddress);
 
@@ -596,6 +603,11 @@ public class YsmMapperPayloadManager {
         mapperSession.setFlag(BuiltinFlags.READ_TIMEOUT, 30_000);
         mapperSession.setFlag(BuiltinFlags.WRITE_TIMEOUT, 30_000);
 
+        final LongAdder adder = this.backend2Players.get(backend);
+        if (adder != null) {
+            adder.increment();
+        }
+
         mapperSession.connect(true, false);
     }
 
@@ -634,32 +646,19 @@ public class YsmMapperPayloadManager {
 
     @Nullable
     private InetSocketAddress selectLessPlayer() {
-        this.backendIpsAccessLock.readLock().lock();
-        try {
-            InetSocketAddress result = null;
+        InetSocketAddress result = null;
+        long lastCount = Long.MAX_VALUE;
 
-            int idx = 0;
-            int lastCount = 0;
-            for (Map.Entry<InetSocketAddress, Integer> entry : this.backend2Players.entrySet()) {
-                final InetSocketAddress currAddress = entry.getKey();
-                final int currPlayerCount = entry.getValue();
+        for (Map.Entry<InetSocketAddress, LongAdder> entry : this.backend2Players.entrySet()) {
+            final InetSocketAddress currAddress = entry.getKey();
+            final long currPlayerCount = entry.getValue().sum();
 
-                if (idx == 0) {
-                    lastCount = currPlayerCount;
-                    result = currAddress;
-                }
-
-                if (currPlayerCount < lastCount) {
-                    lastCount = currPlayerCount;
-                    result = currAddress;
-                }
-
-                idx++;
+            if (result == null || currPlayerCount < lastCount) {
+                lastCount = currPlayerCount;
+                result = currAddress;
             }
-
-            return result;
-        } finally {
-            this.backendIpsAccessLock.readLock().unlock();
         }
+
+        return result;
     }
 }

--- a/Freesia-Waterfall/src/main/java/com/nguyendevs/freesia/waterfall/network/ysm/YsmPacketProxyLayer.java
+++ b/Freesia-Waterfall/src/main/java/com/nguyendevs/freesia/waterfall/network/ysm/YsmPacketProxyLayer.java
@@ -19,6 +19,7 @@ import java.util.Collections;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
 
 public abstract class YsmPacketProxyLayer implements YsmPacketProxy {
     protected final ProxiedPlayer player;
@@ -40,8 +41,8 @@ public abstract class YsmPacketProxyLayer implements YsmPacketProxy {
     private boolean proxyReady = false;
 
     private volatile Set<UUID> cachedTrackerList = Collections.emptySet();
-    private volatile long lastTrackerFetchMs = 0L;
-    private static final long TRACKER_CACHE_TTL_MS = 100L;
+    private volatile long lastTrackerFetchNs = 0L;
+    private static final long TRACKER_CACHE_TTL_NS = TimeUnit.MILLISECONDS.toNanos(100L);
 
     protected static final VarHandle ENTITY_DATA_REF_COUNT_HANDLE = ConcurrentUtil
             .getVarHandle(YsmPacketProxyLayer.class, "entityDataReferenceCount", int.class);
@@ -228,8 +229,8 @@ public abstract class YsmPacketProxyLayer implements YsmPacketProxy {
 
         this.sendEntityStateToRaw(this.playerUUID, currEntityId, currEntityData);
 
-        final long now = System.currentTimeMillis();
-        if (now - this.lastTrackerFetchMs > TRACKER_CACHE_TTL_MS) {
+        final long now = System.nanoTime();
+        if (now - this.lastTrackerFetchNs > TRACKER_CACHE_TTL_NS) {
             this.fetchTrackerList(this.playerUUID).whenComplete((result, ex) -> {
                 if (ex != null) {
                     Freesia.LOGGER.log(java.util.logging.Level.WARNING, "Failed to fetch tracker list for player uuid "
@@ -239,7 +240,7 @@ public abstract class YsmPacketProxyLayer implements YsmPacketProxy {
 
                 if (result != null) {
                     this.cachedTrackerList = result;
-                    this.lastTrackerFetchMs = System.currentTimeMillis();
+                    this.lastTrackerFetchNs = System.nanoTime();
                 }
 
                 this.broadcastStateToTrackers(currEntityId, currEntityData, result);

--- a/Freesia-Waterfall/src/main/java/com/nguyendevs/freesia/waterfall/network/ysm/YsmPacketProxyLayer.java
+++ b/Freesia-Waterfall/src/main/java/com/nguyendevs/freesia/waterfall/network/ysm/YsmPacketProxyLayer.java
@@ -15,6 +15,7 @@ import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
 
 import java.lang.invoke.VarHandle;
+import java.util.Collections;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
@@ -34,10 +35,13 @@ public abstract class YsmPacketProxyLayer implements YsmPacketProxy {
     private int workerEntityId = -1;
 
     private int entityDataReferenceCount = 0;
-
     private YsmState lastYsmEntityData = null;
 
     private boolean proxyReady = false;
+
+    private volatile Set<UUID> cachedTrackerList = Collections.emptySet();
+    private volatile long lastTrackerFetchMs = 0L;
+    private static final long TRACKER_CACHE_TTL_MS = 100L;
 
     protected static final VarHandle ENTITY_DATA_REF_COUNT_HANDLE = ConcurrentUtil
             .getVarHandle(YsmPacketProxyLayer.class, "entityDataReferenceCount", int.class);
@@ -224,23 +228,37 @@ public abstract class YsmPacketProxyLayer implements YsmPacketProxy {
 
         this.sendEntityStateToRaw(this.playerUUID, currEntityId, currEntityData);
 
-        this.fetchTrackerList(this.playerUUID).whenComplete((result, ex) -> {
-            if (ex != null) {
-                Freesia.LOGGER.log(java.util.logging.Level.WARNING, "Failed to fetch tracker list for player uuid "
-                        + (this.player != null ? this.player.getUniqueId() : this.playerUUID) + ": " + ex);
-                return;
-            }
+        final long now = System.currentTimeMillis();
+        if (now - this.lastTrackerFetchMs > TRACKER_CACHE_TTL_MS) {
+            this.fetchTrackerList(this.playerUUID).whenComplete((result, ex) -> {
+                if (ex != null) {
+                    Freesia.LOGGER.log(java.util.logging.Level.WARNING, "Failed to fetch tracker list for player uuid "
+                            + (this.player != null ? this.player.getUniqueId() : this.playerUUID) + ": " + ex);
+                    return;
+                }
 
-            for (UUID toSend : result) {
-                final ProxiedPlayer queryResult = Freesia.PROXY_SERVER.getPlayer(toSend);
+                if (result != null) {
+                    this.cachedTrackerList = result;
+                    this.lastTrackerFetchMs = System.currentTimeMillis();
+                }
 
-                if (queryResult != null) {
-                    if (Freesia.mapperManager.isPlayerInstalledYsm(toSend)) {
-                        this.sendEntityStateToRaw(toSend, currEntityId, currEntityData);
-                    }
+                this.broadcastStateToTrackers(currEntityId, currEntityData, result);
+            });
+        } else {
+            this.broadcastStateToTrackers(currEntityId, currEntityData, this.cachedTrackerList);
+        }
+    }
+
+    private void broadcastStateToTrackers(int entityId, YsmState data, Set<UUID> trackers) {
+        if (trackers == null) return;
+        for (UUID toSend : trackers) {
+            final ProxiedPlayer queryResult = Freesia.PROXY_SERVER.getPlayer(toSend);
+            if (queryResult != null) {
+                if (Freesia.mapperManager.isPlayerInstalledYsm(toSend)) {
+                    this.sendEntityStateToRaw(toSend, entityId, data);
                 }
             }
-        });
+        }
     }
 
     public abstract CompletableFuture<Set<UUID>> fetchTrackerList(UUID observer);

--- a/Freesia-Waterfall/src/main/java/com/nguyendevs/freesia/waterfall/storage/DefaultRealPlayerDataStorageManagerImpl.java
+++ b/Freesia-Waterfall/src/main/java/com/nguyendevs/freesia/waterfall/storage/DefaultRealPlayerDataStorageManagerImpl.java
@@ -23,20 +23,7 @@ public class DefaultRealPlayerDataStorageManagerImpl implements IDataStorageMana
             }
 
             try {
-                final byte[] data = Files.readAllBytes(targetFile.toPath());
-                final ByteArrayInputStream inputStream = new ByteArrayInputStream(data);
-                final DataInputStream dataInputStream = new DataInputStream(inputStream);
-
-                final DefaultNBTSerializer codec = new DefaultNBTSerializer();
-
-                final NBTCompound deserialized = (NBTCompound) codec.deserializeTag(NBTLimiter.noop(), dataInputStream,
-                        true);
-
-                final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-                final DataOutputStream dataOutputStream = new DataOutputStream(outputStream);
-                codec.serializeTag(dataOutputStream, deserialized, false);
-
-                return outputStream.toByteArray();
+                return Files.readAllBytes(targetFile.toPath());
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
@@ -49,19 +36,10 @@ public class DefaultRealPlayerDataStorageManagerImpl implements IDataStorageMana
             final File targetFile = new File(FreesiaConstants.FileConstants.PLAYER_DATA_DIR, playerUUID + ".nbt");
 
             try {
-                final ByteArrayInputStream inputStream = new ByteArrayInputStream(content);
-                final DataInputStream dataInputStream = new DataInputStream(inputStream);
-
                 final DefaultNBTSerializer codec = new DefaultNBTSerializer();
+                codec.deserializeTag(NBTLimiter.forBuffer(content, 2 * 1024 * 1024), new DataInputStream(new ByteArrayInputStream(content)), false);
 
-                final NBTCompound deserialized = (NBTCompound) codec.deserializeTag(NBTLimiter.noop(), dataInputStream,
-                        false);
-
-                final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-                final DataOutputStream dataOutputStream = new DataOutputStream(outputStream);
-                codec.serializeTag(dataOutputStream, deserialized, true);
-
-                Files.write(targetFile.toPath(), outputStream.toByteArray());
+                Files.write(targetFile.toPath(), content);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/Freesia-Waterfall/src/main/java/com/nguyendevs/freesia/waterfall/storage/DefaultVirtualPlayerDataStorageManagerImpl.java
+++ b/Freesia-Waterfall/src/main/java/com/nguyendevs/freesia/waterfall/storage/DefaultVirtualPlayerDataStorageManagerImpl.java
@@ -23,20 +23,7 @@ public class DefaultVirtualPlayerDataStorageManagerImpl implements IDataStorageM
             }
 
             try {
-                final byte[] data = Files.readAllBytes(targetFile.toPath());
-                final ByteArrayInputStream inputStream = new ByteArrayInputStream(data);
-                final DataInputStream dataInputStream = new DataInputStream(inputStream);
-
-                final DefaultNBTSerializer codec = new DefaultNBTSerializer();
-
-                final NBTCompound deserialized = (NBTCompound) codec.deserializeTag(NBTLimiter.noop(), dataInputStream,
-                        true);
-
-                final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-                final DataOutputStream dataOutputStream = new DataOutputStream(outputStream);
-                codec.serializeTag(dataOutputStream, deserialized, false);
-
-                return outputStream.toByteArray();
+                return Files.readAllBytes(targetFile.toPath());
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }
@@ -50,19 +37,10 @@ public class DefaultVirtualPlayerDataStorageManagerImpl implements IDataStorageM
                     playerUUID + ".dat");
 
             try {
-                final ByteArrayInputStream inputStream = new ByteArrayInputStream(content);
-                final DataInputStream dataInputStream = new DataInputStream(inputStream);
-
                 final DefaultNBTSerializer codec = new DefaultNBTSerializer();
+                codec.deserializeTag(NBTLimiter.forBuffer(content, 2 * 1024 * 1024), new DataInputStream(new ByteArrayInputStream(content)), false);
 
-                final NBTCompound deserialized = (NBTCompound) codec.deserializeTag(NBTLimiter.noop(), dataInputStream,
-                        false);
-
-                final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-                final DataOutputStream dataOutputStream = new DataOutputStream(outputStream);
-                codec.serializeTag(dataOutputStream, deserialized, true);
-
-                Files.write(targetFile.toPath(), outputStream.toByteArray());
+                Files.write(targetFile.toPath(), content);
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/Freesia-Worker/src/main/java/com/nguyendevs/freesia/worker/mixin/PlayerDataStorageMixin.java
+++ b/Freesia-Worker/src/main/java/com/nguyendevs/freesia/worker/mixin/PlayerDataStorageMixin.java
@@ -26,25 +26,31 @@ public abstract class PlayerDataStorageMixin {
     @Unique
     private static CompoundTag standardTag;
     @Unique
-    private static boolean loaded = false;
+    private static volatile boolean loaded = false;
 
     @Unique
     private static void loadNullPlayer() {
         if (loaded) {
             return;
         }
-        loaded = true;
 
-        ServerPlayer wrappedNullPlayer = new ServerPlayer(
-                ServerLoader.SERVER_INST,
-                ServerLoader.SERVER_INST.overworld(),
-                new GameProfile(UUID.randomUUID(), "114514"),
-                new ClientInformation("en_US", 4, ChatVisiblity.FULL, true, 0, HumanoidArm.RIGHT, false, true)
-        );
-        final CompoundTag nullTag = new CompoundTag();
-        nullTag.put("cyanidin_null_entity", IntTag.valueOf(1));
-        standardTag = wrappedNullPlayer.saveWithoutId(nullTag);
-        standardTag.remove("cyanidin_null_entity");
+        synchronized (PlayerDataStorageMixin.class) {
+            if (loaded) {
+                return;
+            }
+
+            ServerPlayer wrappedNullPlayer = new ServerPlayer(
+                    ServerLoader.SERVER_INST,
+                    ServerLoader.SERVER_INST.overworld(),
+                    new GameProfile(UUID.randomUUID(), "114514"),
+                    new ClientInformation("en_US", 4, ChatVisiblity.FULL, true, 0, HumanoidArm.RIGHT, false, true)
+            );
+            final CompoundTag nullTag = new CompoundTag();
+            nullTag.put("cyanidin_null_entity", IntTag.valueOf(1));
+            standardTag = wrappedNullPlayer.saveWithoutId(nullTag);
+            standardTag.remove("cyanidin_null_entity");
+            loaded = true;
+        }
     }
 
     @Inject(method = "save", at = @At("HEAD"), cancellable = true)


### PR DESCRIPTION
# Changelog

## [1.0.5-YSM-2.6.4]

### Fixed
- **(common)**: fix reconnection spam and suppress SSL handshake noise
- **(common)**: fix race condition in NettySocketClient where multiple reconnection loops could start
- **(common)**: move reconnection logic to background thread to prevent main thread freeze
- **(proxy)**: use monotonic nanoTime for tracker cache TTL
- **(proxy)**: optimize and fix backend player counting (ConcurrentHashMap + LongAdder)
- **(proxy)**: standardize ysmDetectionTimeout unit to milliseconds
- **(velocity)**: implement atomic save for citizens model cache
- **(worker)**: fix race condition in null player data initialization (Double-checked locking)
- **(waterfall)**: optimize virtual player NBT storage and add size limits
- **(waterfall)**: optimize real player NBT storage and add size limits
- **(velocity)**: optimize virtual player NBT storage and add size limits
- **(velocity)**: optimize NBT storage and add size limits
- **(security)**: implement command whitelist for worker-to-proxy dispatch
- **(common)**: replace recursive connect() with iterative loop to prevent StackOverflowError
- **(perf)**: cache tracker list with 100ms TTL in notifyFullTrackerUpdates
- **(velocity)**: remove blocking .join() on Netty I/O thread in processS2C