### PR TITLE
fix(common): close channel on TooLongFrameException and SSLException

### DIFF
--- a/Freesia-Common/src/main/java/com/nguyendevs/freesia/common/communicating/handler/NettyClientChannelHandlerLayer.java
+++ b/Freesia-Common/src/main/java/com/nguyendevs/freesia/common/communicating/handler/NettyClientChannelHandlerLayer.java
@@ -25,12 +25,20 @@ public abstract class NettyClientChannelHandlerLayer extends SimpleChannelInboun
             return;
         }
 
-        if (cause instanceof io.netty.handler.codec.DecoderException && cause.getCause() instanceof javax.net.ssl.SSLHandshakeException) {
-            EntryPoint.LOGGER_INST.error("SSL handshake failed: {}", cause.getCause().getMessage());
+        if (cause instanceof javax.net.ssl.SSLException) {
+            EntryPoint.LOGGER_INST.error("SSL error: {}", cause.getMessage());
+            ctx.close();
+            return;
+        }
+
+        if (cause instanceof io.netty.handler.codec.TooLongFrameException) {
+            EntryPoint.LOGGER_INST.error("TooLongFrameException: Adjusted frame length exceeds maximum. This may indicate a protocol mismatch between the proxy and the worker. Closing channel.");
+            ctx.close();
             return;
         }
 
         EntryPoint.LOGGER_INST.error("Exception caught in Client channel: ", cause);
+        ctx.close();
     }
 
     @Override

--- a/Freesia-Common/src/main/java/com/nguyendevs/freesia/common/communicating/handler/NettyServerChannelHandlerLayer.java
+++ b/Freesia-Common/src/main/java/com/nguyendevs/freesia/common/communicating/handler/NettyServerChannelHandlerLayer.java
@@ -38,12 +38,20 @@ public abstract class NettyServerChannelHandlerLayer extends SimpleChannelInboun
             return;
         }
 
-        if (cause instanceof io.netty.handler.codec.DecoderException && cause.getCause() instanceof javax.net.ssl.SSLHandshakeException) {
-            EntryPoint.LOGGER_INST.error("SSL handshake failed: {}", cause.getCause().getMessage());
+        if (cause instanceof javax.net.ssl.SSLException) {
+            EntryPoint.LOGGER_INST.error("SSL error: {}", cause.getMessage());
+            ctx.close();
+            return;
+        }
+
+        if (cause instanceof io.netty.handler.codec.TooLongFrameException) {
+            EntryPoint.LOGGER_INST.error("TooLongFrameException: Adjusted frame length exceeds maximum. This may indicate a protocol mismatch between the worker and the proxy. Closing channel.");
+            ctx.close();
             return;
         }
 
         EntryPoint.LOGGER_INST.error("Exception caught in Server channel: ", cause);
+        ctx.close();
     }
 
     public void sendMessage(IMessage<NettyClientChannelHandlerLayer> packet) {


### PR DESCRIPTION
- Handle TooLongFrameException specifically with ctx.close() so worker can reconnect
- Handle broader SSLException instead of just SSLHandshakeException
- Close channel on any non-IOException exception to avoid broken pipeline state